### PR TITLE
Remove useless window.setTimeout call

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -44,6 +44,6 @@ if (document.readyState == "complete") {
 }
 else {
     window.addEventListener("load", function() {
-        setTimeout(sendMetaInfoToExtension(), 0);
+        sendMetaInfoToExtension();
     });
 }


### PR DESCRIPTION
Well, the code has been passing the *value* of `sendMetaInfoToExtension()` to `window.setTimeout` for the past 5 years. That value is `undefined`, which evidently gets subjected to an [approximation of `eval`][1]. There don't seem to be any observable effects of this other than triggering a CSP violation when the page's `script-src` policy doesn't include `unsafe-eval`, so just call `sendMetaInfoToExtension()` and don't set the timeout.