### PR TITLE
contentScript.js: Remove spurious setTimeout()

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -44,6 +44,6 @@ if (document.readyState == "complete") {
 }
 else {
     window.addEventListener("load", function() {
-        setTimeout(sendMetaInfoToExtension(), 0);
+        sendMetaInfoToExtension();
     });
 }


### PR DESCRIPTION
We were calling sendMetaInfoToExtension() first anyway.

Calling `setTimeout(undefined, 0)` after that has little effect;
mainly, it just triggers spurious Content Security Policy errors in Chrome.